### PR TITLE
Bump appVersion in Chart.yml

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ name: shopware-chart
 description: A Helm chart for Shopware 6
 type: application
 version: 0.0.1
-appVersion: 6.2.3
+appVersion: 6.3.0.0
 dependencies:
   - name: mysql
     version: 6.14.4


### PR DESCRIPTION
This PR will just bump the `appVersion` of this chart to the minimum Shopware version `6.3.0.0` that gets supported by the chart including the new versioning strategy.